### PR TITLE
fix: support versions with New Architecture

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -46,6 +46,7 @@ const config = {
         ".png": "dataurl"
     },
     define: {
+        window: "globalThis",
         __DEV__: dev ?? JSON.stringify(releaseBranch !== "main")
     },
     inject: ["./shims/asyncIteratorSymbol.js", "./shims/promiseAllSettled.js"],

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,6 +6,7 @@ declare global {
         var globalEvalWithSourceUrl: (script: string, sourceURL: string) => any;
         var nativePerformanceNow: typeof performance.now;
         var nativeModuleProxy: Record<string, any>;
+        var __turboModuleProxy: (name: string) => any;
 
         interface Window {
                 [key: string]: any;

--- a/src/lib/api/debug.ts
+++ b/src/lib/api/debug.ts
@@ -113,8 +113,8 @@ export function getDebugInfo() {
             }
         },
         discord: {
-            version: NativeClientInfoModule.Version,
-            build: NativeClientInfoModule.Build,
+            version: NativeClientInfoModule.getConstants().Version,
+            build: NativeClientInfoModule.getConstants().Build,
         },
         react: {
             version: React.version,

--- a/src/lib/api/native/modules/index.ts
+++ b/src/lib/api/native/modules/index.ts
@@ -2,10 +2,34 @@ import { RNModules } from "./types";
 
 const nmp = window.nativeModuleProxy;
 
-export const NativeCacheModule = (nmp.NativeCacheModule ?? nmp.MMKVManager) as RNModules.MMKVManager;
-export const NativeFileModule = (nmp.NativeFileModule ?? nmp.RTNFileManager ?? nmp.DCDFileManager) as RNModules.FileManager;
-export const NativeClientInfoModule = nmp.NativeClientInfoModule ?? nmp.RTNClientInfoManager ?? nmp.InfoDictionaryManager;
-export const NativeDeviceModule = nmp.NativeDeviceModule ?? nmp.RTNDeviceManager ?? nmp.DCDDeviceManager;
-export const NativeThemeModule = nmp.NativeThemeModule ?? nmp.RTNThemeManager ?? nmp.DCDTheme;
+function getNativeModule<T = any>(...names: string[]): T | undefined {
+    for (const name of names) {
+        if (globalThis.__turboModuleProxy) {
+            const module = globalThis.__turboModuleProxy(name);
+            if (module) return module as T;
+        }
 
-export const { BundleUpdaterManager } = nmp;
+        if (nmp[name]) return nmp[name] as T;
+    }
+
+    return undefined;
+}
+
+export const NativeCacheModule = getNativeModule<RNModules.MMKVManager>(
+    "NativeCacheModule", "MMKVManager"
+)!;
+export const NativeFileModule = getNativeModule<RNModules.FileManager>(
+    "NativeFileModule", "RTNFileManager", "DCDFileManager"
+)!;
+export const NativeClientInfoModule = getNativeModule<RNModules.ClientInfoModule>(
+    "NativeClientInfoModule", "RTNClientInfoManager", "InfoDictionaryManager"
+)!;
+export const NativeDeviceModule = getNativeModule(
+    "NativeDeviceModule", "RTNDeviceManager", "DCDDeviceManager"
+)!;
+export const NativeThemeModule = getNativeModule(
+    "NativeThemeModule", "RTNThemeManager", "DCDTheme"
+)!;
+export const BundleUpdaterManager = getNativeModule(
+    "BundleUpdaterManager"
+)!;

--- a/src/lib/api/native/modules/types.ts
+++ b/src/lib/api/native/modules/types.ts
@@ -86,4 +86,53 @@ export namespace RNModules {
          */
         DocumentsDirPath: string;
     }
+
+    export interface ClientInfoModule {
+        getConstants(): {
+            /**
+             * Sentry ingestion DSN URL for alpha/beta builds
+             */
+            SentryAlphaBetaDsn: string
+            /**
+             * Sentry ingestion DSN URL for staff builds (?)
+             */
+            SentryStaffDsn: string
+            /**
+             * Sentry ingestion DSN URL for stable builds
+             */
+            SentryDsn: string
+            DeviceVendorID: string
+            Manifest: string
+            /**
+             * Version code
+             *
+             * Follows the format of `{MINOR}{CHANNEL}{PATCH}` for `{MINOR}.{PATCH} ({CHANNEL})`
+             * - `248200` for `248.0 (alpha)`
+             * - `247105` for `247.5 (beta)`
+             * - `246011` for `246.11 (stable)`
+             */
+            Build: string
+            /**
+             * Version string
+             *
+             * Eg. `248.0`
+             */
+            Version: string
+            /**
+             * Release channel
+             */
+            ReleaseChannel: string
+            /**
+             * Matches `Version`
+             */
+            OTABuild: string
+            /**
+             * Identifier for the installed client
+             *
+             * - **Android**: Package name
+             * - **iOS**: Bundle ID
+             */
+            Identifier: string
+        }
+    }
 }

--- a/src/metro/internals/caches.ts
+++ b/src/metro/internals/caches.ts
@@ -18,7 +18,7 @@ export const getMetroCache = () => _metroCache;
 function buildInitCache() {
     const cache = {
         _v: CACHE_VERSION,
-        _buildNumber: NativeClientInfoModule.Build as number,
+        _buildNumber: NativeClientInfoModule.getConstants().Build,
         _modulesCount: Object.keys(window.modules).length,
         flagsIndex: {} as Record<string, number>,
         findIndex: {} as Record<string, ModulesMap | undefined>,
@@ -48,7 +48,7 @@ export async function initMetroCache() {
             _metroCache = null!;
             throw "cache invalidated; cache version outdated";
         }
-        if (_metroCache._buildNumber !== NativeClientInfoModule.Build) {
+        if (_metroCache._buildNumber !== NativeClientInfoModule.getConstants().Build) {
             _metroCache = null!;
             throw "cache invalidated; version mismatch";
         }


### PR DESCRIPTION
I'm bored, and I swear I saw an open offer to submit a pull request for this in the announcements. Couldn't find it anymore after fixing it, but figured I'd PR it anyway.

## Changes
- Retrieve turbo modules from `global.__turboModuleProxy`
- Use `getConstants()` to retrieve constants of native modules
- Defer some calls from the native bridge/JSI that could break the app when bundle index is not initialized properly

Resolves #186
Tested on Android 291.0 (291200), **not yet tested on older versions** (without New Architecture)